### PR TITLE
Create IPLDs for state trie nodes in a range of blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,11 @@ A [VulcanizeDB](https://github.com/vulcanize/VulcanizeDB) transformer for creati
 - `./block_watcher createIpldsForBlocksTransactions --config <config.toml> --starting-block-number <block-number> --ending-block-number <block-number>`
 - Note: starting and ending block number arguments are required, and ending block number must be greater than starting block number.
 
+## Running the createIpldsForStateTrie command
+- This command creates IPLDs for state trie nodes in a range of Ethereum blocks.
+- `./block_watcher createIpldsForStateTrie --config <config.toml> --starting-block-number <block-number> --ending-block-number <block-number>`
+- Note: requires running an archive node. LevelDB lookup for state trie will fail otherwise due to state pruning.
+
 ## Running the tests
 ```
 ginkgo -r

--- a/cmd/createIpldForBlockHeaders.go
+++ b/cmd/createIpldForBlockHeaders.go
@@ -47,6 +47,10 @@ func init() {
 }
 
 func createIpldForBlockHeaders() {
+	if endingBlockNumber < startingBlockNumber {
+		log.Fatal("Ending block number must be greater than or equal to starting block number.")
+	}
+
 	// init eth db
 	ethDBConfig := db.CreateDatabaseConfig(db.Level, levelDbPath)
 	ethDB, err := db.CreateDatabase(ethDBConfig)

--- a/cmd/createIpldsForBlocksTransactions.go
+++ b/cmd/createIpldsForBlocksTransactions.go
@@ -46,6 +46,10 @@ func init() {
 }
 
 func createIpldsForBlocksTransactions() {
+	if endingBlockNumber < startingBlockNumber {
+		log.Fatal("Ending block number must be greater than or equal to starting block number.")
+	}
+
 	// init eth db
 	ethDBConfig := db.CreateDatabaseConfig(db.Level, levelDbPath)
 	ethDB, err := db.CreateDatabase(ethDBConfig)

--- a/cmd/createIpldsForStateTrie.go
+++ b/cmd/createIpldsForStateTrie.go
@@ -1,0 +1,79 @@
+// Copyright © 2018 Rob Mulholand <rmulholand@8thlight.com>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"log"
+
+	"github.com/spf13/cobra"
+
+	"github.com/vulcanize/block_watcher/pkg/db"
+	"github.com/vulcanize/block_watcher/pkg/ipfs"
+	"github.com/vulcanize/block_watcher/pkg/ipfs/eth_state_trie"
+	"github.com/vulcanize/block_watcher/pkg/transformers"
+)
+
+// createIpldsForStateTrieCmd represents the createIpldsForStateTrie command
+var createIpldsForStateTrieCmd = &cobra.Command{
+	Use:   "createIpldsForStateTrie",
+	Short: "Create iplds for every ethereum state trie node",
+	Long: `Create iplds for every ethereum state trie node. For example:
+
+./block_watcher createIpldsForStateTrie
+
+Note that this operation is very expensive in terms of both cpu and disk,
+as it is reconstructing the entire ethereum state trie in the same fashion
+as an archive node.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		createIpldsForStateTrie()
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(createIpldsForStateTrieCmd)
+	createIpldsForStateTrieCmd.Flags().Int64VarP(&startingBlockNumber, "starting-block-number", "s", 0, "First block number to create IPLD for.")
+	createIpldsForStateTrieCmd.Flags().Int64VarP(&endingBlockNumber, "ending-block-number", "e", 5430000, "Last block number to create IPLD for.")
+}
+
+func createIpldsForStateTrie() {
+	if endingBlockNumber < startingBlockNumber {
+		log.Fatal("Ending block number must be greater than or equal to starting block number.")
+	}
+
+	// init eth db
+	databaseConfig := db.CreateDatabaseConfig(db.Level, levelDbPath)
+	database, err := db.CreateDatabase(databaseConfig)
+	if err != nil {
+		log.Fatal("Error connecting to the ethereum db: ", err)
+	}
+
+	// init decoder
+	decoder := db.RlpDecoder{}
+
+	// init ipfs publisher
+	adder, err := ipfs.InitIPFSNode(ipfsPath)
+	if err != nil {
+		log.Fatal("Error connecting to ipfs: ", err)
+	}
+	dagPutter := eth_state_trie.NewStateTrieDagPutter(adder)
+	publisher := ipfs.NewIpfsPublisher(dagPutter)
+
+	// init and execute transformer
+	transformer := transformers.NewEthStateTrieTransformer(database, decoder, publisher)
+	err = transformer.Execute(startingBlockNumber, endingBlockNumber)
+	if err != nil {
+		log.Fatal("Error executing transformer: ", err)
+	}
+}

--- a/pkg/db/database.go
+++ b/pkg/db/database.go
@@ -22,6 +22,7 @@ func (re ReadError) Error() string {
 type Database interface {
 	GetBlockBodyByBlockNumber(blockNumber int64) ([]byte, error)
 	GetBlockHeaderByBlockNumber(blockNumber int64) ([]byte, error)
+	GetStateTrieNodes(root []byte) ([][]byte, error)
 }
 
 func CreateDatabase(config DatabaseConfig) (Database, error) {

--- a/pkg/db/level/database.go
+++ b/pkg/db/level/database.go
@@ -1,10 +1,12 @@
 package level
 
+import "github.com/ethereum/go-ethereum/common"
+
 type Database struct {
-	reader
+	reader Reader
 }
 
-func NewLevelDatabase(ldbReader reader) *Database {
+func NewLevelDatabase(ldbReader Reader) *Database {
 	return &Database{
 		reader: ldbReader,
 	}
@@ -20,4 +22,9 @@ func (l Database) GetBlockHeaderByBlockNumber(blockNumber int64) ([]byte, error)
 	n := uint64(blockNumber)
 	h := l.reader.GetCanonicalHash(n)
 	return l.reader.GetHeaderRLP(h, n), nil
+}
+
+func (l Database) GetStateTrieNodes(root []byte) ([][]byte, error) {
+	h := common.BytesToHash(root)
+	return l.reader.GetStateTrieNodes(h)
 }

--- a/pkg/db/level/database_test.go
+++ b/pkg/db/level/database_test.go
@@ -10,41 +10,68 @@ import (
 )
 
 var _ = Describe("Database", func() {
-	Describe("Getting block header data", func() {
+	Describe("Getting block body data", func() {
 		It("invokes the level database reader to query for block hash by block number", func() {
 			mockLevelDBReader := test_helpers.NewMockLevelDatabaseReader()
 			db := level.NewLevelDatabase(mockLevelDBReader)
+			num := int64(123456)
 
-			_, err := db.GetBlockHeaderByBlockNumber(12345)
-
-			Expect(err).NotTo(HaveOccurred())
-			Expect(mockLevelDBReader.GetHashCalled).To(BeTrue())
-		})
-
-		It("invokes the level database reader to query for block header data", func() {
-			mockLevelDBReader := test_helpers.NewMockLevelDatabaseReader()
-			db := level.NewLevelDatabase(mockLevelDBReader)
-
-			_, err := db.GetBlockHeaderByBlockNumber(12345)
+			_, err := db.GetBlockBodyByBlockNumber(num)
 
 			Expect(err).NotTo(HaveOccurred())
-			Expect(mockLevelDBReader.GetHeaderCalled).To(BeTrue())
+			mockLevelDBReader.AssertGetCanonicalHashCalledWith(uint64(num))
 		})
 
-		It("converts block data to required format", func() {
+		It("invokes the level database reader to query for block body data", func() {
 			mockLevelDBReader := test_helpers.NewMockLevelDatabaseReader()
 			hash := common.HexToHash("abcde")
-			mockLevelDBReader.SetReturnHash(hash)
+			mockLevelDBReader.SetGetCanonicalHashReturnHash(hash)
+			db := level.NewLevelDatabase(mockLevelDBReader)
+			num := int64(123456)
+
+			_, err := db.GetBlockBodyByBlockNumber(num)
+
+			Expect(err).NotTo(HaveOccurred())
+			mockLevelDBReader.AssertGetBodyRLPCalledWith(hash, uint64(num))
+		})
+	})
+
+	Describe("Getting block header data", func() {
+		It("invokes the level database reader to query for block hash by block number", func() {
+			mockLevelDBReader := test_helpers.NewMockLevelDatabaseReader()
 			db := level.NewLevelDatabase(mockLevelDBReader)
 			num := int64(123456)
 
 			_, err := db.GetBlockHeaderByBlockNumber(num)
 
 			Expect(err).NotTo(HaveOccurred())
-			Expect(mockLevelDBReader.PassedHash).To(Equal(hash))
-			expectedBlockNumber := uint64(num)
-			Expect(mockLevelDBReader.PassedNumber).To(Equal(expectedBlockNumber))
+			mockLevelDBReader.AssertGetCanonicalHashCalledWith(uint64(num))
+		})
+
+		It("invokes the level database reader to query for block header data", func() {
+			mockLevelDBReader := test_helpers.NewMockLevelDatabaseReader()
+			hash := common.HexToHash("abcde")
+			mockLevelDBReader.SetGetCanonicalHashReturnHash(hash)
+			db := level.NewLevelDatabase(mockLevelDBReader)
+			num := int64(123456)
+
+			_, err := db.GetBlockHeaderByBlockNumber(num)
+
+			Expect(err).NotTo(HaveOccurred())
+			mockLevelDBReader.AssertGetHeaderRLPCalledWith(hash, uint64(num))
 		})
 	})
 
+	Describe("Getting state trie nodes", func() {
+		It("invokes the level database reader to query for state trie data", func() {
+			mockLevelDBReader := test_helpers.NewMockLevelDatabaseReader()
+			db := level.NewLevelDatabase(mockLevelDBReader)
+			root := common.HexToHash("abcde")
+
+			_, err := db.GetStateTrieNodes(root.Bytes())
+
+			Expect(err).NotTo(HaveOccurred())
+			mockLevelDBReader.AssertGetStateTrieNodesCalledWith(root)
+		})
+	})
 })

--- a/pkg/ipfs/eth_block_header/dag_putter_test.go
+++ b/pkg/ipfs/eth_block_header/dag_putter_test.go
@@ -1,11 +1,12 @@
 package eth_block_header_test
 
 import (
+	"errors"
+
+	"github.com/ethereum/go-ethereum/core/types"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	"errors"
-	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/vulcanize/block_watcher/pkg/ipfs/eth_block_header"
 	"github.com/vulcanize/block_watcher/test_helpers"
 )

--- a/pkg/ipfs/eth_state_trie/dag_putter.go
+++ b/pkg/ipfs/eth_state_trie/dag_putter.go
@@ -1,0 +1,42 @@
+package eth_state_trie
+
+import (
+	"github.com/vulcanize/block_watcher/pkg/ipfs"
+	"github.com/vulcanize/block_watcher/pkg/ipfs/util"
+)
+
+const (
+	EthStateTrieNodeCode = 0x96
+)
+
+type StateTrieDagPutter struct {
+	adder ipfs.Adder
+}
+
+func NewStateTrieDagPutter(adder ipfs.Adder) *StateTrieDagPutter {
+	return &StateTrieDagPutter{adder: adder}
+}
+
+func (stdp StateTrieDagPutter) DagPut(raw []byte) ([]string, error) {
+	stateTrieNode, err := stdp.getStateTrieNode(raw)
+	if err != nil {
+		return nil, err
+	}
+	err = stdp.adder.Add(stateTrieNode)
+	if err != nil {
+		return nil, err
+	}
+	return []string{stateTrieNode.Cid().String()}, nil
+}
+
+func (stdp StateTrieDagPutter) getStateTrieNode(raw []byte) (*EthStateTrieNode, error) {
+	stateTrieNodeCid, err := util.RawToCid(EthStateTrieNodeCode, raw)
+	if err != nil {
+		return nil, err
+	}
+	stateTrieNode := &EthStateTrieNode{
+		cid:     stateTrieNodeCid,
+		rawdata: raw,
+	}
+	return stateTrieNode, nil
+}

--- a/pkg/ipfs/eth_state_trie/dag_putter_test.go
+++ b/pkg/ipfs/eth_state_trie/dag_putter_test.go
@@ -1,0 +1,35 @@
+package eth_state_trie_test
+
+import (
+	"errors"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/vulcanize/block_watcher/pkg/ipfs/eth_state_trie"
+	"github.com/vulcanize/block_watcher/test_helpers"
+)
+
+var _ = Describe("Ethereum state trie node dag putter", func() {
+	It("adds passed state trie node to ipfs", func() {
+		mockAdder := test_helpers.NewMockAdder()
+		dagPutter := eth_state_trie.NewStateTrieDagPutter(mockAdder)
+
+		_, err := dagPutter.DagPut([]byte{1, 2, 3, 4, 5})
+
+		Expect(err).NotTo(HaveOccurred())
+		mockAdder.AssertAddCalled(1, &eth_state_trie.EthStateTrieNode{})
+	})
+
+	It("returns error if adding to ipfs fails", func() {
+		mockAdder := test_helpers.NewMockAdder()
+		fakeError := errors.New("failed")
+		mockAdder.SetError(fakeError)
+		dagPutter := eth_state_trie.NewStateTrieDagPutter(mockAdder)
+
+		_, err := dagPutter.DagPut([]byte{1, 2, 3, 4, 5})
+
+		Expect(err).To(HaveOccurred())
+		Expect(err).To(MatchError(fakeError))
+	})
+})

--- a/pkg/ipfs/eth_state_trie/eth_state_trie_suite_test.go
+++ b/pkg/ipfs/eth_state_trie/eth_state_trie_suite_test.go
@@ -1,0 +1,13 @@
+package eth_state_trie_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestEthStateTrie(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "EthStateTrie Suite")
+}

--- a/pkg/ipfs/eth_state_trie/node.go
+++ b/pkg/ipfs/eth_state_trie/node.go
@@ -1,0 +1,55 @@
+package eth_state_trie
+
+import (
+	"gx/ipfs/QmcZfnkapfECQGcLZaf9B79NRg7cRa9EnZh4LSbkCzwNvY/go-cid"
+	"gx/ipfs/Qme5bWv7wtjUNGsK2BNGVUFPKiuxWrsqrtvYwCLRw8YFES/go-ipld-format"
+)
+
+type EthStateTrieNode struct {
+	cid     *cid.Cid
+	rawdata []byte
+}
+
+func (estn EthStateTrieNode) RawData() []byte {
+	return estn.rawdata
+}
+
+func (estn EthStateTrieNode) Cid() *cid.Cid {
+	return estn.cid
+}
+
+func (EthStateTrieNode) String() string {
+	panic("implement me")
+}
+
+func (EthStateTrieNode) Loggable() map[string]interface{} {
+	panic("implement me")
+}
+
+func (EthStateTrieNode) Resolve(path []string) (interface{}, []string, error) {
+	panic("implement me")
+}
+
+func (EthStateTrieNode) Tree(path string, depth int) []string {
+	panic("implement me")
+}
+
+func (EthStateTrieNode) ResolveLink(path []string) (*format.Link, []string, error) {
+	panic("implement me")
+}
+
+func (EthStateTrieNode) Copy() format.Node {
+	panic("implement me")
+}
+
+func (EthStateTrieNode) Links() []*format.Link {
+	panic("implement me")
+}
+
+func (EthStateTrieNode) Stat() (*format.NodeStat, error) {
+	panic("implement me")
+}
+
+func (EthStateTrieNode) Size() (uint64, error) {
+	panic("implement me")
+}

--- a/pkg/transformers/eth_state_trie.go
+++ b/pkg/transformers/eth_state_trie.go
@@ -1,0 +1,64 @@
+package transformers
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+
+	"github.com/vulcanize/block_watcher/pkg/db"
+	"github.com/vulcanize/block_watcher/pkg/ipfs"
+)
+
+type EthStateTrieTransformer struct {
+	database  db.Database
+	decoder   db.Decoder
+	publisher ipfs.Publisher
+}
+
+func NewEthStateTrieTransformer(database db.Database, decoder db.Decoder, publisher ipfs.Publisher) *EthStateTrieTransformer {
+	return &EthStateTrieTransformer{database: database, decoder: decoder, publisher: publisher}
+}
+
+func (t EthStateTrieTransformer) Execute(startingBlockNumber int64, endingBlockNumber int64) error {
+	for i := startingBlockNumber; i <= endingBlockNumber; i++ {
+		root, err := t.getStateRootForBlock(i)
+		if err != nil {
+			return err
+		}
+
+		stateTrieNodes, err := t.database.GetStateTrieNodes(root.Bytes())
+		if err != nil {
+			return fmt.Errorf("Error fetching state trie for block %d: %s\n", i, err)
+		}
+
+		err = t.writeStateTrieNodesToIpfs(stateTrieNodes)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (t EthStateTrieTransformer) getStateRootForBlock(blockNumber int64) (common.Hash, error) {
+	var header types.Header
+	rawHeader, err := t.database.GetBlockHeaderByBlockNumber(blockNumber)
+	if err != nil {
+		return common.Hash{}, fmt.Errorf("Error fetching header for block %d: %s\n", blockNumber, err)
+	}
+	out, err := t.decoder.Decode(rawHeader, &header)
+	parsedHeader := out.(*types.Header)
+	return parsedHeader.Root, nil
+}
+
+func (t EthStateTrieTransformer) writeStateTrieNodesToIpfs(stateTrieNodes [][]byte) error {
+	for _, node := range stateTrieNodes {
+		output, err := t.publisher.Write(node)
+		if err != nil {
+			return fmt.Errorf("Error writing state trie node to ipfs: %s\n", err)
+		}
+		log.Println("Created ipld: ", output)
+	}
+	return nil
+}

--- a/pkg/transformers/eth_state_trie_test.go
+++ b/pkg/transformers/eth_state_trie_test.go
@@ -1,0 +1,94 @@
+package transformers_test
+
+import (
+	"io/ioutil"
+	"log"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"gx/ipfs/QmVmDhyTTUcQXFD1rRQ64fGLMSAoaQvNH3hwuaCFAPq2hy/errors"
+
+	"github.com/vulcanize/block_watcher/pkg/transformers"
+	"github.com/vulcanize/block_watcher/test_helpers"
+)
+
+var _ = Describe("Ethereum state trie transformer", func() {
+	BeforeEach(func() {
+		log.SetOutput(ioutil.Discard)
+	})
+
+	It("fetches block header for block", func() {
+		mockDatabase := test_helpers.NewMockDatabase()
+		mockDatabase.SetHeaderByBlockNumberReturnBytes([][]byte{{1, 2, 3, 4, 5}})
+		mockDecoder := test_helpers.NewMockDecoder()
+		mockDecoder.SetReturnOut(&types.Header{})
+		transformer := transformers.NewEthStateTrieTransformer(mockDatabase, mockDecoder, test_helpers.NewMockPublisher())
+
+		err := transformer.Execute(0, 0)
+
+		Expect(err).NotTo(HaveOccurred())
+		mockDatabase.AssertGetBlockHeaderByBlockNumberCalledWith([]int64{0})
+	})
+
+	It("returns err if fetching block header returns err", func() {
+		mockDatabase := test_helpers.NewMockDatabase()
+		fakeError := errors.New("header fetching failed")
+		mockDatabase.SetHeaderByBlockNumberError(fakeError)
+		transformer := transformers.NewEthStateTrieTransformer(mockDatabase, test_helpers.NewMockDecoder(), test_helpers.NewMockPublisher())
+
+		err := transformer.Execute(0, 0)
+
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring(fakeError.Error()))
+	})
+
+	It("fetches state trie nodes with state root from decoded block header", func() {
+		mockDatabase := test_helpers.NewMockDatabase()
+		fakeHeader := []byte{6, 7, 8, 9, 0}
+		mockDatabase.SetHeaderByBlockNumberReturnBytes([][]byte{fakeHeader})
+		mockDecoder := test_helpers.NewMockDecoder()
+		rootHash := common.HexToHash("0x12345")
+		mockDecoder.SetReturnOut(&types.Header{Root: rootHash})
+		transformer := transformers.NewEthStateTrieTransformer(mockDatabase, mockDecoder, test_helpers.NewMockPublisher())
+
+		err := transformer.Execute(0, 0)
+
+		Expect(err).NotTo(HaveOccurred())
+		mockDecoder.AssertDecodeCalledWith(fakeHeader, &types.Header{})
+		mockDatabase.AssertGetStateTrieNodesCalledWith(rootHash.Bytes())
+	})
+
+	It("returns err if fetching state trie returns err", func() {
+		mockDatabase := test_helpers.NewMockDatabase()
+		mockDatabase.SetHeaderByBlockNumberReturnBytes([][]byte{{1, 2, 3, 4, 5}})
+		fakeError := errors.New("state trie fetching failed")
+		mockDatabase.SetStateTrieNodesError(fakeError)
+		mockDecoder := test_helpers.NewMockDecoder()
+		mockDecoder.SetReturnOut(&types.Header{Root: common.Hash{}})
+		transformer := transformers.NewEthStateTrieTransformer(mockDatabase, mockDecoder, test_helpers.NewMockPublisher())
+
+		err := transformer.Execute(0, 0)
+
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring(fakeError.Error()))
+	})
+
+	It("writes state trie nodes to ipfs", func() {
+		mockDatabase := test_helpers.NewMockDatabase()
+		mockDatabase.SetHeaderByBlockNumberReturnBytes([][]byte{{1, 2, 3, 4, 5}})
+		fakeStateTrieNodes := [][]byte{{1, 2, 3, 4, 5}, {6, 7, 8, 9, 0}}
+		mockDatabase.SetStateTrieNodesReturnBytes(fakeStateTrieNodes)
+		mockDecoder := test_helpers.NewMockDecoder()
+		mockDecoder.SetReturnOut(&types.Header{})
+		mockPublisher := test_helpers.NewMockPublisher()
+		mockPublisher.SetReturnStrings([][]string{{"one"}, {"two"}})
+		transformer := transformers.NewEthStateTrieTransformer(mockDatabase, mockDecoder, mockPublisher)
+
+		err := transformer.Execute(0, 0)
+
+		Expect(err).NotTo(HaveOccurred())
+		mockPublisher.AssertWriteCalledWith(fakeStateTrieNodes)
+	})
+})

--- a/test_helpers/mock_database.go
+++ b/test_helpers/mock_database.go
@@ -11,6 +11,9 @@ type MockDatabase struct {
 	headerByBlockNumberErr                error
 	headerByBlockNumberReturnBytes        [][]byte
 	headerByBlockNumberPassedBlockNumbers []int64
+	stateTrieNodesErr                     error
+	stateTrieNodesPassedRoot              []byte
+	stateTrieNodesReturnBytes             [][]byte
 }
 
 func NewMockDatabase() *MockDatabase {
@@ -21,6 +24,9 @@ func NewMockDatabase() *MockDatabase {
 		headerByBlockNumberErr:                nil,
 		headerByBlockNumberReturnBytes:        nil,
 		headerByBlockNumberPassedBlockNumbers: nil,
+		stateTrieNodesErr:                     nil,
+		stateTrieNodesPassedRoot:              nil,
+		stateTrieNodesReturnBytes:             nil,
 	}
 }
 
@@ -32,12 +38,20 @@ func (md *MockDatabase) SetHeaderByBlockNumberReturnBytes(returnBytes [][]byte) 
 	md.headerByBlockNumberReturnBytes = returnBytes
 }
 
+func (md *MockDatabase) SetStateTrieNodesReturnBytes(returnBytes [][]byte) {
+	md.stateTrieNodesReturnBytes = returnBytes
+}
+
 func (md *MockDatabase) SetBodyByBlockNumberError(err error) {
 	md.bodyByBlockNumberErr = err
 }
 
 func (md *MockDatabase) SetHeaderByBlockNumberError(err error) {
 	md.headerByBlockNumberErr = err
+}
+
+func (md *MockDatabase) SetStateTrieNodesError(err error) {
+	md.stateTrieNodesErr = err
 }
 
 func (md *MockDatabase) GetBlockBodyByBlockNumber(blockNumber int64) ([]byte, error) {
@@ -60,10 +74,19 @@ func (md *MockDatabase) GetBlockHeaderByBlockNumber(blockNumber int64) ([]byte, 
 	return returnBytes, nil
 }
 
+func (md *MockDatabase) GetStateTrieNodes(root []byte) ([][]byte, error) {
+	md.stateTrieNodesPassedRoot = root
+	return md.stateTrieNodesReturnBytes, md.stateTrieNodesErr
+}
+
 func (md *MockDatabase) AssertGetBlockBodyByBlockNumberCalledWith(blockNumbers []int64) {
 	Expect(md.bodyByBlockNumberPassedBlockNumbers).To(Equal(blockNumbers))
 }
 
 func (md *MockDatabase) AssertGetBlockHeaderByBlockNumberCalledWith(blockNumbers []int64) {
 	Expect(md.headerByBlockNumberPassedBlockNumbers).To(Equal(blockNumbers))
+}
+
+func (md *MockDatabase) AssertGetStateTrieNodesCalledWith(root []byte) {
+	Expect(md.stateTrieNodesPassedRoot).To(Equal(root))
 }

--- a/test_helpers/mock_level_database_reader.go
+++ b/test_helpers/mock_level_database_reader.go
@@ -3,48 +3,83 @@ package test_helpers
 import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/rlp"
+	. "github.com/onsi/gomega"
 )
 
 type MockLevelDatabaseReader struct {
-	GetBodyCalled   bool
-	GetHashCalled   bool
-	GetHeaderCalled bool
-	PassedHash      common.Hash
-	PassedNumber    uint64
-	ReturnHash      common.Hash
+	getBodyRLPPassedHash         common.Hash
+	getBodyRLPPassedNumber       uint64
+	getCanonicalHashPassedNumber uint64
+	getCanonicalHashReturnHash   common.Hash
+	getHeaderRLPPassedHash       common.Hash
+	getHeaderRLPPassedNumber     uint64
+	getStateTrieNodesPassedRoot  common.Hash
+	getStateTrieNodesReturnErr   error
+	getStateTrieNodesReturnBytes [][]byte
 }
 
 func NewMockLevelDatabaseReader() *MockLevelDatabaseReader {
 	return &MockLevelDatabaseReader{
-		GetBodyCalled:   false,
-		GetHashCalled:   false,
-		GetHeaderCalled: false,
-		PassedHash:      common.Hash{},
-		PassedNumber:    0,
-		ReturnHash:      common.Hash{},
+		getBodyRLPPassedHash:         common.Hash{},
+		getBodyRLPPassedNumber:       0,
+		getCanonicalHashPassedNumber: 0,
+		getCanonicalHashReturnHash:   common.Hash{},
+		getHeaderRLPPassedHash:       common.Hash{},
+		getHeaderRLPPassedNumber:     0,
+		getStateTrieNodesPassedRoot:  common.Hash{},
+		getStateTrieNodesReturnErr:   nil,
+		getStateTrieNodesReturnBytes: nil,
 	}
 }
 
-func (mldr *MockLevelDatabaseReader) SetReturnHash(hash common.Hash) {
-	mldr.ReturnHash = hash
+func (mldr *MockLevelDatabaseReader) SetGetCanonicalHashReturnHash(hash common.Hash) {
+	mldr.getCanonicalHashReturnHash = hash
 }
 
-func (mldr *MockLevelDatabaseReader) GetCanonicalHash(number uint64) common.Hash {
-	mldr.GetHashCalled = true
-	mldr.PassedNumber = number
-	return mldr.ReturnHash
+func (mldr *MockLevelDatabaseReader) SetGetStateTrieNodesReturnBytes(returnBytes [][]byte) {
+	mldr.getStateTrieNodesReturnBytes = returnBytes
 }
 
-func (mldr *MockLevelDatabaseReader) GetHeaderRLP(hash common.Hash, number uint64) rlp.RawValue {
-	mldr.GetHeaderCalled = true
-	mldr.PassedHash = hash
-	mldr.PassedNumber = number
-	return nil
+func (mldr *MockLevelDatabaseReader) SetGetStateTrieNodesReturnErr(err error) {
+	mldr.getStateTrieNodesReturnErr = err
 }
 
 func (mldr *MockLevelDatabaseReader) GetBodyRLP(hash common.Hash, number uint64) rlp.RawValue {
-	mldr.GetBodyCalled = true
-	mldr.PassedHash = hash
-	mldr.PassedNumber = number
+	mldr.getBodyRLPPassedHash = hash
+	mldr.getBodyRLPPassedNumber = number
 	return nil
+}
+
+func (mldr *MockLevelDatabaseReader) GetCanonicalHash(number uint64) common.Hash {
+	mldr.getCanonicalHashPassedNumber = number
+	return mldr.getCanonicalHashReturnHash
+}
+
+func (mldr *MockLevelDatabaseReader) GetHeaderRLP(hash common.Hash, number uint64) rlp.RawValue {
+	mldr.getHeaderRLPPassedHash = hash
+	mldr.getHeaderRLPPassedNumber = number
+	return nil
+}
+
+func (mldr *MockLevelDatabaseReader) GetStateTrieNodes(root common.Hash) ([][]byte, error) {
+	mldr.getStateTrieNodesPassedRoot = root
+	return mldr.getStateTrieNodesReturnBytes, mldr.getStateTrieNodesReturnErr
+}
+
+func (mldr *MockLevelDatabaseReader) AssertGetBodyRLPCalledWith(hash common.Hash, number uint64) {
+	Expect(mldr.getBodyRLPPassedHash).To(Equal(hash))
+	Expect(mldr.getBodyRLPPassedNumber).To(Equal(number))
+}
+
+func (mldr *MockLevelDatabaseReader) AssertGetCanonicalHashCalledWith(number uint64) {
+	Expect(mldr.getCanonicalHashPassedNumber).To(Equal(number))
+}
+
+func (mldr *MockLevelDatabaseReader) AssertGetHeaderRLPCalledWith(hash common.Hash, number uint64) {
+	Expect(mldr.getHeaderRLPPassedHash).To(Equal(hash))
+	Expect(mldr.getHeaderRLPPassedNumber).To(Equal(number))
+}
+
+func (mldr *MockLevelDatabaseReader) AssertGetStateTrieNodesCalledWith(root common.Hash) {
+	Expect(mldr.getStateTrieNodesPassedRoot).To(Equal(root))
 }


### PR DESCRIPTION
- Requires running an archive node to lookup state trie in LevelDB (state trie nodes are pruned in non-archive sync).

Resolves #3 